### PR TITLE
Add css import to fix button vertical alignment.

### DIFF
--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import Vuetify from 'vuetify'
+import 'material-design-icons-iconfont/dist/material-design-icons.css'
 import 'vuetify/dist/vuetify.min.css'
 
 Vue.use(Vuetify, {


### PR DESCRIPTION
FAB buttons had their icon not vertically aligned in some cases (e.g., in IE or Office taskpanes). This import fixes it.

Before:
![image](https://user-images.githubusercontent.com/45694155/64196799-a147fb00-ce52-11e9-87c8-2dcec2b7a2a7.png)

After:
![image](https://user-images.githubusercontent.com/45694155/64196827-ad33bd00-ce52-11e9-9fba-f2ceaa244b3d.png)

Source:
https://stackoverflow.com/questions/51268313/vuetifys-fab-button-icon-is-not-centered-vertically

