### PR TITLE
capitalisation of client types

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -76,7 +76,7 @@ export default new Vuex.Store( {
       client.objects = objects
       client.AccountId = account.AccountId
       client.account = { RestApi: account.RestApi, Email: account.Email, Token: account.Token }
-      client.type = 'sender'
+      client.type = 'Sender'
       client.expired = true
       client.loading = false
       client.loadingBlurb = 'This stream might be expired.'
@@ -109,7 +109,7 @@ export default new Vuex.Store( {
 
       client.AccountId = account.AccountId
       client.account = { RestApi: account.RestApi, Email: account.Email, Token: account.Token }
-      client.type = 'receiver'
+      client.type = 'Receiver'
       client.expired = true
       client.loading = false
       client.loadingBlurb = ''


### PR DESCRIPTION
Maybe not an issue per se, but just wanted to point this out...

I noticed that the `client.type` in `store.js` is specificied either as a `sender` or `receiver` (not capitalized). However, the current `SpeckleRhino` app produces clients which are specified as `Sender` or `Receiver` (capitalized). Not sure what is right or wrong, but I think it should be consistent and the exact same everywhere? 

**Affected project:**
For example, this affects SpeckleViz, as it checks for `Sender` and `Receiver` types and not `sender` or `receiver` types... SpeckleExcel, on the other hand, built with `SpeckleUiApp`, produces `sender` or `receiver` types. This results in isolated Excel islands which are disconnected on the graph, see below ¯\_(ツ)_/¯

I'm aware that I'm very nit-picky here, I could also convert all the types in lowercase and check them against it in SpeckleViz, but I think beyond the latter, it's good to remain consistent through all repos...

![image](https://user-images.githubusercontent.com/22736626/75045539-5c288b80-54bb-11ea-9860-3f63ecd4bc78.png)
